### PR TITLE
Made credentials and projectId optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,6 @@ module.exports = {
         }
       },
 
-      requiredConfig: [
-        'credentials',
-        'projectId'
-      ],
-
       upload: function(context) {
         var self = this;
         var credentials = this.readConfig('credentials');
@@ -41,16 +36,21 @@ module.exports = {
 
         this.log('uploading..');
 
-        return upload(this, {
-          gcloud: {
-            credentials: credentials,
-            projectId: projectId
-          },
+        var config = {
           bucket: bucket,
           fileBase: context.distDir,
           filePaths: filesToUpload,
           gzippedFilePaths: gzippedFiles
-        })
+        };
+        
+        if ( projectId && credentials ) {
+          config['gcloud'] = {
+            credentials: credentials,
+            projectId: projectId
+          };
+        }
+
+        return upload(this, config)
         .then(function (filesUploaded) {
           self.log('uploaded ' + filesUploaded.length + ' files ok', { verbose: true });
           return { filesUploaded: filesUploaded };


### PR DESCRIPTION
I use system authentication and env variable to specify project and authentication information. With this `GCLOUD_PROJECT=<project_id> ember deploy`, I don't need to specify projectId and credentials in config. So, I made them optional with this PR. 
