### PR TITLE
Added the ability to specify metadata via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ember deploy production
 - `distFiles` - Files that need to be deployed, defaults to all files in the `dist` directory.
 - `gzippedFiles` - Files that are already gzipped, hence not requiring more gzipping. This defaults to values from `ember-cli-deploy-gzip`.
 - `filePattern` - Applied to the `distFiles` via minimatch.
+- `metadata` - Hash of metadata properties to be applied to uploaded files.
 
 ## TODO
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = {
         var distFiles = this.readConfig('distFiles');
         var gzippedFiles = this.readConfig('gzippedFiles');
         var filePattern = this.readConfig('filePattern');
+        var metadata = this.readConfig('metadata');
         var filesToUpload = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
 
         this.log('uploading..');
@@ -42,7 +43,8 @@ module.exports = {
           bucketFolder: bucketFolder,
           fileBase: context.distDir,
           filePaths: filesToUpload,
-          gzippedFilePaths: gzippedFiles
+          gzippedFilePaths: gzippedFiles,
+          metadata: metadata
         };
 
         if ( projectId && credentials ) {

--- a/libs/upload.js
+++ b/libs/upload.js
@@ -17,7 +17,7 @@ module.exports = function uploadToGCS(plugin, config) {
       if (path.sep === "\\") {
         destinationFilePath = destinationFilePath.replace(/\\/g, "/")
       }
-      var metadata = isGzipped ? {contentEncoding:"gzip"} : {}
+      var metadata = Object.assign({}, isGzipped ? {contentEncoding:"gzip"} : {}, config.metadata);
       return bucket.upload(basePath, {
         destination:destinationFilePath,
         metadata:metadata,


### PR DESCRIPTION
This PR adds the ability to specify metadata for files that are uploaded to Google Storage. It allows to specify `cacheControl` property like this

```js
/* jshint node: true */

module.exports = function() {
  return {
    'gcloud-storage': {
      projectId: 'contributor-days',
      bucket: 'contributor-days-assets',
      metadata: {
        cacheControl: 'public, max-age=31536000'
      }
    }
  };
};

```