### PR TITLE
fix deprecation warning `use rsvp instead of ember-cli/lib/ext/promise`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var minimatch = require('minimatch');
 var BasePlugin = require('ember-cli-deploy-plugin');
-var Promise = require('ember-cli/lib/ext/promise');
+var Promise = require('rsvp').Promise;
 var upload = require('./libs/upload');
 
 module.exports = {

--- a/libs/upload.js
+++ b/libs/upload.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var storage = require('@google-cloud/storage');
-var Promise = require('ember-cli/lib/ext/promise');
+var Promise = require('rsvp').Promise;
 
 
 module.exports = function uploadToGCS(plugin, config) {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "@google-cloud/storage": "^0.2.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-deploy-plugin": "^0.2.6",
-    "minimatch": "^3.0.2"
+    "minimatch": "^3.0.2",
+    "rsvp":"^3.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Title says it all 